### PR TITLE
feat(ewl): expose express winston options

### DIFF
--- a/packages/ewl/README.md
+++ b/packages/ewl/README.md
@@ -113,19 +113,17 @@ bootstrap();
 ```typescript
 const ewl = new Ewl({
   enableRequestLogging: false,
-});
-
-// Set express-winston middleware options
-ewl.createRequestMiddleware({
-  bodyBlacklist: ['accessToken', 'password', 'refreshToken'],
-  colorize: true,
-  expressFormat: true,
-  headerBlacklist: ['cookie', 'token'],
-  meta: true,
-  metaField: 'express',
-  requestWhitelist: ['body', 'headers', 'method', 'params', 'query', 'url'],
-  responseWhitelist: ['body', 'headers', 'statusCode'],
-  statusLevels: true,
+  requestLoggingOptions: {
+    bodyBlacklist: ['accessToken', 'password', 'refreshToken'],
+    colorize: true,
+    expressFormat: true,
+    headerBlacklist: ['cookie', 'token'],
+    meta: true,
+    metaField: 'express',
+    requestWhitelist: ['body', 'headers', 'method', 'params', 'query', 'url'],
+    responseWhitelist: ['body', 'headers', 'statusCode'],
+    statusLevels: true,
+  },
 });
 
 // Use request middleware to inject express metadata.

--- a/packages/ewl/src/config/index.ts
+++ b/packages/ewl/src/config/index.ts
@@ -1,21 +1,29 @@
-import { plainToInstance } from 'class-transformer';
+import { Type, plainToInstance } from 'class-transformer';
 import {
   IsBoolean,
   IsIn,
+  IsObject,
   IsOptional,
   IsString,
+  ValidateNested,
   ValidationError,
   validateSync,
 } from 'class-validator';
+import { BaseLoggerOptions } from 'express-winston';
+import 'reflect-metadata';
+
+import { RequestLoggingConfig } from './request-logging.config';
 
 export type Environment = 'development' | 'production' | 'staging' | 'test' | string;
 export type LogLevel = 'debug' | 'error' | 'info' | 'log' | 'verbose' | 'warn';
+export { RequestLoggingConfig } from './request-logging.config';
 
 export interface Options {
   enableRequestLogging: boolean;
   environment: Environment;
   label: string;
   logLevel: LogLevel;
+  requestLoggingOptions: BaseLoggerOptions;
   useLogstashFormat: boolean;
   version: string;
 }
@@ -45,6 +53,13 @@ export class Config implements Options {
   @IsIn(['debug', 'error', 'info', 'log', 'verbose', 'warn'])
   @IsOptional()
   readonly logLevel: LogLevel = 'error';
+
+  // Set to true to use the logstash formatter (typically for kubernetes environments).
+  @ValidateNested()
+  @Type(() => RequestLoggingConfig)
+  @IsObject()
+  @IsOptional()
+  readonly requestLoggingOptions: BaseLoggerOptions = new RequestLoggingConfig();
 
   // Set to true to use the logstash formatter (typically for kubernetes environments).
   @IsBoolean()

--- a/packages/ewl/src/config/request-logging.config.ts
+++ b/packages/ewl/src/config/request-logging.config.ts
@@ -1,0 +1,104 @@
+import { IsArray, IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
+import {
+  BaseLoggerOptions,
+  DynamicLevelFunction,
+  DynamicMetaFunction,
+  MessageTemplate,
+  RequestFilter,
+  ResponseFilter,
+  RouteFilter,
+  StatusLevels,
+} from 'express-winston';
+import { Format } from 'logform';
+
+export class RequestLoggingConfig implements BaseLoggerOptions {
+  @IsObject()
+  @IsOptional()
+  readonly baseMeta?: object;
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly bodyBlacklist: string[] = ['accessToken', 'password', 'refreshToken', 'token'];
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly bodyWhitelist?: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  readonly colorize = false;
+
+  @IsOptional()
+  readonly dynamicMeta?: DynamicMetaFunction;
+
+  @IsBoolean()
+  @IsOptional()
+  readonly expressFormat = true;
+
+  @IsOptional()
+  readonly format?: Format;
+
+  @IsOptional()
+  readonly ignoreRoute: RouteFilter = /* istanbul ignore next */ (): boolean => false;
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly ignoredRoutes?: string[];
+
+  @IsOptional()
+  readonly level?: string | DynamicLevelFunction;
+
+  @IsBoolean()
+  @IsOptional()
+  readonly meta = true;
+
+  @IsString()
+  @IsOptional()
+  readonly metaField = 'express';
+
+  @IsString()
+  @IsOptional()
+  readonly requestField?: string | null;
+
+  @IsString()
+  @IsOptional()
+  readonly responseField?: string | null;
+
+  @IsString()
+  @IsOptional()
+  readonly msg: MessageTemplate = '{{req.method}} {{req.url}}';
+
+  @IsOptional()
+  readonly requestFilter?: RequestFilter;
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly requestWhitelist: string[] = ['body', 'headers', 'method', 'params', 'query', 'url'];
+
+  @IsOptional()
+  readonly responseFilter?: ResponseFilter;
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly responseWhitelist: string[] = ['body', 'headers', 'statusCode'];
+
+  @IsString({ each: true })
+  @IsArray()
+  @IsOptional()
+  readonly headerBlacklist: string[] = ['cookie', 'token'];
+
+  @IsOptional()
+  readonly skip?: RouteFilter;
+
+  @IsOptional()
+  readonly statusLevels: boolean | StatusLevels = true;
+
+  @IsBoolean()
+  @IsOptional()
+  readonly allowFilterOutWhitelistedRequestBody?: boolean;
+}

--- a/packages/ewl/src/index.ts
+++ b/packages/ewl/src/index.ts
@@ -54,17 +54,7 @@ export class Ewl {
     };
 
     if (config.enableRequestLogging) {
-      this.createRequestMiddleware({
-        bodyBlacklist: ['accessToken', 'password', 'refreshToken'],
-        colorize: config.environment === 'development',
-        expressFormat: true,
-        headerBlacklist: ['cookie', 'token'],
-        meta: true,
-        metaField: 'express',
-        requestWhitelist: ['body', 'headers', 'method', 'params', 'query', 'url'],
-        responseWhitelist: ['body', 'headers', 'statusCode'],
-        statusLevels: true,
-      });
+      this.createRequestMiddleware(config.requestLoggingOptions);
     }
   }
 
@@ -137,16 +127,12 @@ export class Ewl {
    */
   createRequestMiddleware(options: BaseLoggerOptions): void {
     this.requestMiddleware = expressWinstonLogger({
-      expressFormat: false,
-      ignoreRoute: /* istanbul ignore next */ () => false,
-      meta: true,
-      metaField: 'express',
-      msg: '{{req.method}} {{req.url}}',
       requestFilter: /* istanbul ignore next */ (req: FilterRequest, propertyName: string) =>
         sanitizeRequest(req, propertyName, options),
       responseFilter: /* istanbul ignore next */ (res: FilterResponse, propertyName: string) =>
         sanitizeResponse(res, propertyName, options),
       ...options,
+      // This is handled internally by the sanitize methods.
       bodyBlacklist: [],
       winstonInstance: this.logger,
     });

--- a/packages/ewl/src/sanitizer.ts
+++ b/packages/ewl/src/sanitizer.ts
@@ -38,7 +38,7 @@ export function sanitizeRequest(
   }
   if (propertyName === 'headers') {
     // The 'if-none-match' header can break logstash JSON format.
-    if ('if-none-match' in req.headers) req.headers['if-none-match'] = 'EXCLUDED';
+    if ('if-none-match' in req.headers) req.headers['if-none-match'] = '[EXCLUDED]';
     // The 'authorization' header has the plaintext jwt, we should never log it.
     if (req.headers.authorization) req.headers.authorization = 'Bearer [REDACTED]';
     // The 'cookie' headers could contain jwt's.

--- a/packages/ewl/test/jest.config.js
+++ b/packages/ewl/test/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = Object.assign({}, require(`kalos/packages/ewl/jest.config.js`), {
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/config/request-logging.config.ts'],
   coverageDirectory: '<rootDir>/coverage',
   testMatch: ['**/test/**/*.spec.ts'],
 });

--- a/packages/ewl/test/specs/config/index.spec.ts
+++ b/packages/ewl/test/specs/config/index.spec.ts
@@ -1,4 +1,4 @@
-import { Config, LogLevel } from '../../src/config';
+import { Config, LogLevel } from '../../../src/config';
 
 describe('Config', () => {
   describe('formatValidationErrors', () => {
@@ -35,12 +35,35 @@ describe('Config', () => {
       });
     });
 
-    test('should should errors if validation fails', () => {
+    test('should create errors if validation fails', () => {
       const options = {
         enableRequestLogging: true,
         environment: 'development',
         label: 'app',
         logLevel: 'not-valid' as LogLevel,
+        requestLoggingOptions: {
+          allowFilterOutWhitelistedRequestBody: undefined,
+          baseMeta: undefined,
+          bodyBlacklist: ['accessToken', 'password', 'refreshToken', 'token'],
+          bodyWhitelist: undefined,
+          colorize: false,
+          expressFormat: true,
+          format: undefined,
+          headerBlacklist: ['cookie', 'token'],
+          ignoreRoute: expect.any(Function),
+          ignoredRoutes: undefined,
+          meta: true,
+          metaField: 'express',
+          msg: '{{req.method}} {{req.url}}',
+          requestField: undefined,
+          requestFilter: undefined,
+          requestWhitelist: ['body', 'headers', 'method', 'params', 'query', 'url'],
+          responseField: undefined,
+          responseFilter: undefined,
+          responseWhitelist: ['body', 'headers', 'statusCode'],
+          skip: undefined,
+          statusLevels: true,
+        },
         useLogstashFormat: false,
         version: 'unknown',
       };

--- a/packages/ewl/test/specs/config/request-logging.config.spec.ts
+++ b/packages/ewl/test/specs/config/request-logging.config.spec.ts
@@ -1,0 +1,56 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { RequestLoggingConfig } from '../../../src/config';
+
+describe('Request Logging Config', () => {
+  const options = {
+    allowFilterOutWhitelistedRequestBody: undefined,
+    baseMeta: undefined,
+    bodyBlacklist: ['accessToken', 'password', 'refreshToken', 'token'],
+    bodyWhitelist: undefined,
+    colorize: false,
+    expressFormat: true,
+    format: undefined,
+    headerBlacklist: ['cookie', 'token'],
+    ignoreRoute: expect.any(Function),
+    ignoredRoutes: undefined,
+    meta: true,
+    metaField: 'express',
+    msg: '{{req.method}} {{req.url}}',
+    requestField: undefined,
+    requestFilter: undefined,
+    requestWhitelist: ['body', 'headers', 'method', 'params', 'query', 'url'],
+    responseField: undefined,
+    responseFilter: undefined,
+    responseWhitelist: ['body', 'headers', 'statusCode'],
+    skip: undefined,
+    statusLevels: true,
+  };
+
+  describe('validate', () => {
+    test('should populate configuration defaults correctly', () => {
+      const config = plainToInstance(RequestLoggingConfig, {});
+      expect(config).toMatchObject(options);
+    });
+
+    test('should create errors if validation fails', () => {
+      const config = plainToInstance(RequestLoggingConfig, { ...options, colorize: 'some-string' });
+      const errors = validateSync(config, {
+        forbidUnknownValues: true,
+        whitelist: true,
+      });
+      expect(errors).toMatchObject([
+        {
+          children: [],
+          constraints: {
+            isBoolean: 'colorize must be a boolean value',
+          },
+          property: 'colorize',
+          target: { ...options, colorize: 'some-string' },
+          value: 'some-string',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/ewl/test/specs/index.spec.ts
+++ b/packages/ewl/test/specs/index.spec.ts
@@ -24,6 +24,9 @@ describe('EWL', () => {
       environment: 'development',
       label: 'app',
       logLevel: 'debug' as LogLevel,
+      requestLoggingOptions: {
+        colorize: true,
+      },
       useLogstashFormat: false,
       version: 'unknown',
     });

--- a/packages/ewl/test/specs/sanitizer.spec.ts
+++ b/packages/ewl/test/specs/sanitizer.spec.ts
@@ -35,7 +35,7 @@ describe('Sanitizer', () => {
       ).toEqual({
         authorization: 'Bearer [REDACTED]',
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'if-none-match': 'EXCLUDED',
+        'if-none-match': '[EXCLUDED]',
         cookie: 'AccessToken=[REDACTED]; RefreshToken=[REDACTED]; OtherCookie=NoSecret',
       });
     });


### PR DESCRIPTION
# Overview

Allow `express-winston` to be configured using the `requestLoggerOptions` property.

## Checklist

- [x] I have documented the changes to the source code
- [x] I have added test coverage
